### PR TITLE
Remove quotes from undodir variable in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Now this plug-in will free you from those commands and bring back the power of u
 // In your vimrc
 
     if has("persistent_undo")
-        set undodir='~/.undodir/'
+        set undodir=~/.undodir/
         set undofile
     endif
 


### PR DESCRIPTION
Having quotes, either single or double, prevents persistent undo from working. This is to complete the recommendation in #21. 
